### PR TITLE
[RHDM-536] Decision Central OpenShift container does not expose Git HTTP and SSH ports

### DIFF
--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -30,6 +30,8 @@ modules:
 artifacts:
     - path: rhdm-7.0.0.GA-decision-central-eap7-deployable.zip
       md5:  ac487d47aab652588336c50c13bc8ad6
+ports:
+    - value: 8001
 run:
       user: 185
       cmd:


### PR DESCRIPTION
[RHDM-536] Decision Central OpenShift container does not expose Git HTTP and SSH ports
https://issues.jboss.org/browse/RHDM-536

Signed-off-by: David Ward <dward@redhat.com>