### PR TITLE
[RHPAM-891] maven users created in eap unnecessarily

### DIFF
--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -16,7 +16,7 @@ labels:
 envs:
     - name: "JBOSS_PRODUCT"
       value: "rhdm-kieserver"
-    - name: "JBOSS_RHDM_KIESERVER_VERSION"
+    - name: "RHDM_KIESERVER_VERSION"
       value: "7.0.1"
     - name: "PRODUCT_VERSION"
       value: "7.0.1"


### PR DESCRIPTION
[RHPAM-891] maven users created in eap unnecessarily
https://issues.jboss.org/browse/RHPAM-891

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
