### PR TITLE
[RHDM-630] Update RHDM OpenShift images from 7.0.1.CR1 to 7.0.1.CR2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# rhdm-7-image
+Red Hat Decision Manager 7 standalone images
+

--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -29,7 +29,7 @@ modules:
           - name: decisioncentral
 artifacts:
     - path: rhdm-7.0.1.GA-decision-central-eap7-deployable.zip
-      md5:  1332eb8e0fbc6f343120471511d6fab1
+      md5:  12830b0c09f5993d980ceb3dd3c48dc7
 ports:
     - value: 8001
 run:

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -29,7 +29,7 @@ modules:
           - name: kieserver
 artifacts:
     - path: rhdm-7.0.1.GA-kie-server-ee7.zip
-      md5:  0712d9a59328446bf3ab0a68405a586f
+      md5:  dc8be349441e92b7b496dbb8160b8dc2
 run:
       user: 185
       cmd:


### PR DESCRIPTION
[RHDM-630] Update RHDM OpenShift images from 7.0.1.CR1 to 7.0.1.CR2
https://issues.jboss.org/browse/RHDM-630

Signed-off-by: David Ward <dward@redhat.com>