### PR TITLE
[KIECLOUD-20] Update RHDM images to be based on EAP 7.2.x with CR1 binaries

### DIFF
--- a/controller/modules/controller/module.yaml
+++ b/controller/modules/controller/module.yaml
@@ -22,8 +22,8 @@ envs:
       value: "rhdm-7.2-controller-ee7.zip"
 artifacts:
     - name: ADD_ONS_DISTRIBUTION.ZIP
-      path: rhdm-7.2.0.DM-redhat-20181114-add-ons.zip
-      md5: dc34c67d0ebe8da634e4f38ec032fab1
+      path: rhdm-7.2.0-add-ons.zip
+      md5: e91b6fb6c5edabb2faf6e3d0432b48d1
 run:
       user: 185
       cmd:

--- a/decisioncentral/modules/decisioncentral/module.yaml
+++ b/decisioncentral/modules/decisioncentral/module.yaml
@@ -24,8 +24,8 @@ ports:
     - value: 8001
 artifacts:
     - name: DECISION_CENTRAL_DISTRIBUTION.ZIP
-      path: rhdm-7.2.0.DM-redhat-20181114-decision-central-eap7-deployable.zip
-      md5: 99f7638a346b37773f87eefbf1b9ed17
+      path: rhdm-7.2.0-decision-central-eap7-deployable.zip
+      md5: 63d354a0278a2f9e9abc466c6ebc71bc
 run:
       user: 185
       cmd:

--- a/kieserver/modules/kieserver/module.yaml
+++ b/kieserver/modules/kieserver/module.yaml
@@ -20,8 +20,8 @@ envs:
       value: "KIE_SERVER_DISTRIBUTION.ZIP"
 artifacts:
     - name: KIE_SERVER_DISTRIBUTION.ZIP
-      path: rhdm-7.2.0.DM-redhat-20181114-kie-server-ee7.zip
-      md5: f86e0f1c9122f9cf98c0d5b1c792b655
+      path: rhdm-7.2.0-kie-server-ee7.zip
+      md5: 0cccdba3433cf13bab1caea491789962
 run:
       user: 185
       cmd:

--- a/optaweb-employee-rostering/modules/optaweb-employee-rostering/module.yaml
+++ b/optaweb-employee-rostering/modules/optaweb-employee-rostering/module.yaml
@@ -21,12 +21,12 @@ envs:
     - name: "EMPLOYEE_ROSTERING_DISTRIBUTION_ZIP"
       value: "rhdm-7.2-employee-rostering.zip"
     - name: "EMPLOYEE_ROSTERING_DISTRIBUTION_WAR"
-      value: "employee-rostering-distribution-7.2.0.redhat-20181114/binaries/employee-rostering-webapp-7.2.0.redhat-20181114.war"
+      value: "employee-rostering-distribution-7.14.0.Final-redhat-00001/binaries/employee-rostering-webapp-7.14.0.Final-redhat-00001.war"
 # remember to also update "EMPLOYEE_ROSTERING_DISTRIBUTION_WAR" value
 artifacts:
     - name: ADD_ONS_DISTRIBUTION.ZIP
-      path: rhdm-7.2.0.DM-redhat-20181114-add-ons.zip
-      md5: dc34c67d0ebe8da634e4f38ec032fab1
+      path: rhdm-7.2.0-add-ons.zip
+      md5: e91b6fb6c5edabb2faf6e3d0432b48d1
 run:
       user: 185
       cmd:


### PR DESCRIPTION
[KIECLOUD-20] Update RHDM images to be based on EAP 7.2.x with CR1 binaries
https://issues.jboss.org/browse/KIECLOUD-20

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
