### PR TITLE
[KIECLOUD-236] align RHDM 7.4.0 images with appropriate EAP 7.2.1 tags

### DIFF
--- a/controller/artifact-overrides.yaml
+++ b/controller/artifact-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 #          not updated from "path" to "name". See "Artifact types" here:
 #          https://docs.cekit.io/en/latest/descriptor/module.html#artifact-types
 #          Currently used for jenkins builds for continuous integration.
-#   Usage: cekit --overrides-file branch-overrides.yaml \
-#                --overrides-file artifact-overrides.yaml
+#   Usage: cekit build --overrides-file branch-overrides.yaml \
+#                      --overrides-file artifact-overrides.yaml
 
 artifacts:
     - name: "jboss-eap-7.2.1-patch.zip"

--- a/controller/branch-overrides.yaml
+++ b/controller/branch-overrides.yaml
@@ -14,5 +14,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/controller/tag-overrides.yaml
+++ b/controller/tag-overrides.yaml
@@ -15,5 +15,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/decisioncentral/artifact-overrides.yaml
+++ b/decisioncentral/artifact-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 #          not updated from "path" to "name". See "Artifact types" here:
 #          https://docs.cekit.io/en/latest/descriptor/module.html#artifact-types
 #          Currently used for jenkins builds for continuous integration.
-#   Usage: cekit --overrides-file branch-overrides.yaml \
-#                --overrides-file artifact-overrides.yaml
+#   Usage: cekit build --overrides-file branch-overrides.yaml \
+#                      --overrides-file artifact-overrides.yaml
 
 artifacts:
     - name: "jboss-eap-7.2.1-patch.zip"

--- a/decisioncentral/branch-overrides.yaml
+++ b/decisioncentral/branch-overrides.yaml
@@ -14,5 +14,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/decisioncentral/tag-overrides.yaml
+++ b/decisioncentral/tag-overrides.yaml
@@ -15,5 +15,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/kieserver/artifact-overrides.yaml
+++ b/kieserver/artifact-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 #          not updated from "path" to "name". See "Artifact types" here:
 #          https://docs.cekit.io/en/latest/descriptor/module.html#artifact-types
 #          Currently used for jenkins builds for continuous integration.
-#   Usage: cekit --overrides-file branch-overrides.yaml \
-#                --overrides-file artifact-overrides.yaml
+#   Usage: cekit build --overrides-file branch-overrides.yaml \
+#                      --overrides-file artifact-overrides.yaml
 
 artifacts:
     - name: "jboss-eap-7.2.1-patch.zip"

--- a/kieserver/branch-overrides.yaml
+++ b/kieserver/branch-overrides.yaml
@@ -14,5 +14,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/kieserver/modules/kieserver/module.yaml
+++ b/kieserver/modules/kieserver/module.yaml
@@ -25,8 +25,8 @@ artifacts:
       md5: "ae242527818e70ccb83403faa0cb1ddb"
     - name: "slf4j-simple.jar"
       target: "slf4j-simple.jar"
-      #     slf4j-simple-1.7.22.redhat-1.jar
-      md5: "51c319582c16a07c21e41737e45cb03a"
+      #     slf4j-simple-1.7.22.redhat-2.jar
+      md5: "62cc6eeb72e2738e3acc8957ca95f37b"
 run:
       user: 185
       cmd:

--- a/kieserver/tag-overrides.yaml
+++ b/kieserver/tag-overrides.yaml
@@ -15,5 +15,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/optaweb-employee-rostering/artifact-overrides.yaml
+++ b/optaweb-employee-rostering/artifact-overrides.yaml
@@ -5,8 +5,8 @@ schema_version: 1
 #          not updated from "path" to "name". See "Artifact types" here:
 #          https://docs.cekit.io/en/latest/descriptor/module.html#artifact-types
 #          Currently used for jenkins builds for continuous integration.
-#   Usage: cekit --overrides-file branch-overrides.yaml \
-#                --overrides-file artifact-overrides.yaml
+#   Usage: cekit build --overrides-file branch-overrides.yaml \
+#                      --overrides-file artifact-overrides.yaml
 
 artifacts:
     - name: "jboss-eap-7.2.1-patch.zip"

--- a/optaweb-employee-rostering/branch-overrides.yaml
+++ b/optaweb-employee-rostering/branch-overrides.yaml
@@ -14,5 +14,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3

--- a/optaweb-employee-rostering/tag-overrides.yaml
+++ b/optaweb-employee-rostering/tag-overrides.yaml
@@ -15,5 +15,4 @@ modules:
           - name: jboss-eap-7-image
             git:
                   url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-                  # TODO: replace with GA tag when available
                   ref: EAP_721_CR3


### PR DESCRIPTION
[KIECLOUD-236] align RHDM 7.4.0 images with appropriate EAP 7.2.1 tags
https://issues.jboss.org/browse/KIECLOUD-236

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
